### PR TITLE
Server data file inclusions make issue 

### DIFF
--- a/websocket_server/main/component.mk
+++ b/websocket_server/main/component.mk
@@ -1,1 +1,1 @@
-COMPONENT_PRIV_INCLUDEDIRS := server
+COMPONENT_EMBED_FILES := ./server/error.html ./server/favicon.ico ./server/root.html ./server/test.css ./server/test.js

--- a/websocket_server/main/server/component.mk
+++ b/websocket_server/main/server/component.mk
@@ -1,2 +1,0 @@
-# files to add to the web server
-COMPONENT_EMBED_FILES := root.html error.html test.js test.css favicon.ico


### PR DESCRIPTION
I'm seeing the same issue that is described here [https://github.com/Molorius/esp32-websocket/issues/9](https://github.com/Molorius/esp32-websocket/issues/9) and I could only make it build by moving the `COMPONENT_EMBED_FILES` section to the main component make file.

Since it builds fine for others I'm wondering what the root cause is. It looks like the `server/component.mk` file is not included when I build the project since I get a linking error and not an error about a missing resource (`[...] needed by 'embed_bin/[...]`).

I have tried to build with _esp-idf v3.2_ and _v3.3-beta1-427-g1aa8e8d38_ on _Linux Mint 19.1_.

Since I couldn't find a way to make the existing (cleaner) build setup run I make this PR with the reasoning that it makes  the example code run for more users.